### PR TITLE
[FIX] HA 2026.2 - Fix DHCP service info deprecation/removal 

### DIFF
--- a/custom_components/linknlink/config_flow.py
+++ b/custom_components/linknlink/config_flow.py
@@ -14,10 +14,10 @@ from linknlink.exceptions import (
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components import dhcp
 from homeassistant.const import CONF_HOST, CONF_MAC, CONF_TIMEOUT, CONF_TYPE
 from homeassistant.data_entry_flow import AbortFlow, FlowResult
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from .const import DEFAULT_TIMEOUT, DEVICE_TYPES, DOMAIN
 
@@ -53,7 +53,7 @@ class linknlinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             "host": device.host[0],
         }
 
-    async def async_step_dhcp(self, discovery_info: dhcp.DhcpServiceInfo) -> FlowResult:
+    async def async_step_dhcp(self, discovery_info: DhcpServiceInfo) -> FlowResult:
         """Handle dhcp discovery."""
         host = discovery_info.ip
         unique_id = discovery_info.macaddress.lower().replace(":", "")

--- a/custom_components/linknlink/config_flow.py
+++ b/custom_components/linknlink/config_flow.py
@@ -17,7 +17,11 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_MAC, CONF_TIMEOUT, CONF_TYPE
 from homeassistant.data_entry_flow import AbortFlow, FlowResult
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+
+try:
+    from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+except ImportError:
+    from homeassistant.components.dhcp import DhcpServiceInfo
 
 from .const import DEFAULT_TIMEOUT, DEVICE_TYPES, DOMAIN
 

--- a/custom_components/linknlink/manifest.json
+++ b/custom_components/linknlink/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "local_polling",
   "loggers": ["linknlink"],
   "requirements": ["linknlink==0.2.4"],
-  "version": "2024.5.9"
+  "version": "2026.2.0"
 }


### PR DESCRIPTION
2026.2 moved the DHCP service info import, breaking LinknLink local. This fixes it.

*yes I was lazy and used Claude for something I definitely could have done myself 😆 