### PR TITLE
Fix DhcpServiceInfo import for newer Home Assistant versions

### DIFF
--- a/custom_components/linknlink/config_flow.py
+++ b/custom_components/linknlink/config_flow.py
@@ -14,10 +14,10 @@ from linknlink.exceptions import (
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components import dhcp
 from homeassistant.const import CONF_HOST, CONF_MAC, CONF_TIMEOUT, CONF_TYPE
 from homeassistant.data_entry_flow import AbortFlow, FlowResult
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from .const import DEFAULT_TIMEOUT, DEVICE_TYPES, DOMAIN
 
@@ -53,7 +53,7 @@ class linknlinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             "host": device.host[0],
         }
 
-    async def async_step_dhcp(self, discovery_info: dhcp.DhcpServiceInfo) -> FlowResult:
+    async def async_step_dhcp(self, discovery_info: DhcpServiceInfo) -> FlowResult:
         """Handle dhcp discovery."""
         host = discovery_info.ip
         unique_id = discovery_info.macaddress.lower().replace(":", "")


### PR DESCRIPTION
DhcpServiceInfo was moved from homeassistant.components.dhcp to homeassistant.helpers.service_info.dhcp in recent Home Assistant releases.

https://claude.ai/code/session_01Jf7Nfmjg87aWsHq4xGrAA4