### PR TITLE
Update config flow type hints to use ConfigFlowResult

### DIFF
--- a/custom_components/linknlink/config_flow.py
+++ b/custom_components/linknlink/config_flow.py
@@ -14,10 +14,11 @@ from linknlink.exceptions import (
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components import dhcp
+from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_MAC, CONF_TIMEOUT, CONF_TYPE
-from homeassistant.data_entry_flow import AbortFlow, FlowResult
+from homeassistant.data_entry_flow import AbortFlow
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from .const import DEFAULT_TIMEOUT, DEVICE_TYPES, DOMAIN
 
@@ -53,7 +54,7 @@ class linknlinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             "host": device.host[0],
         }
 
-    async def async_step_dhcp(self, discovery_info: dhcp.DhcpServiceInfo) -> FlowResult:
+    async def async_step_dhcp(self, discovery_info: DhcpServiceInfo) -> ConfigFlowResult:
         """Handle dhcp discovery."""
         host = discovery_info.ip
         unique_id = discovery_info.macaddress.lower().replace(":", "")
@@ -78,7 +79,7 @@ class linknlinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Handle a flow initiated by the user."""
         errors = {}
 
@@ -126,7 +127,7 @@ class linknlinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    async def async_step_auth(self) -> FlowResult:
+    async def async_step_auth(self) -> ConfigFlowResult:
         """Authenticate to the device."""
         device = self.device
         errors = {}
@@ -167,7 +168,7 @@ class linknlinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         )
         return self.async_show_form(step_id="auth", errors=errors)
 
-    async def async_step_reset(self, user_input=None, errors=None) -> FlowResult:
+    async def async_step_reset(self, user_input=None, errors=None) -> ConfigFlowResult:
         """Guide the user to unlock the device manually.
 
         We are unable to authenticate because the device is locked.
@@ -190,7 +191,7 @@ class linknlinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             {CONF_HOST: device.host[0], CONF_TIMEOUT: device.timeout}
         )
 
-    async def async_step_unlock(self, user_input=None) -> FlowResult:
+    async def async_step_unlock(self, user_input=None) -> ConfigFlowResult:
         """Unlock the device.
 
         The authentication succeeded, but the device is locked.
@@ -244,7 +245,7 @@ class linknlinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             },
         )
 
-    async def async_finish(self) -> FlowResult:
+    async def async_finish(self) -> ConfigFlowResult:
         """Create config entry."""
         device = self.device
 


### PR DESCRIPTION
## Summary
Updated the config flow module to use Home Assistant's `ConfigFlowResult` type hint instead of the deprecated `FlowResult` type, and improved import organization for DHCP-related types.

## Key Changes
- Replaced all `FlowResult` return type hints with `ConfigFlowResult` across all async step methods (`async_step_dhcp`, `async_step_user`, `async_step_auth`, `async_step_reset`, `async_step_unlock`, and `async_finish`)
- Updated imports to use `ConfigFlowResult` from `homeassistant.config_entries` instead of `FlowResult` from `homeassistant.data_entry_flow`
- Changed DHCP service info import from `homeassistant.components.dhcp` to `homeassistant.helpers.service_info.dhcp.DhcpServiceInfo` for better type specificity
- Removed unused `dhcp` module import from `homeassistant.components`
- Removed unused `FlowResult` import from `homeassistant.data_entry_flow`

## Implementation Details
These changes align with Home Assistant's current best practices for config flow type hints. `ConfigFlowResult` is the recommended type for all config flow step methods, providing better type safety and consistency across the codebase.
